### PR TITLE
Binder button for the q model

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ dependencies:
 - ipython
 - numba
 - dolo==0.4.9.15
-- dolang==0.0.15
+- dolang==0.0.14
 - numexpr
 - numpy
 - numpydoc

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -11,7 +11,7 @@ statsmodels
 dolang
 altair
 dolo==0.4.9.15
-dolang==0.0.15
+dolang==0.0.14
 tqdm
 altair
 jupyterlab>=1.0

--- a/chimeras/qModel/README.md
+++ b/chimeras/qModel/README.md
@@ -1,0 +1,5 @@
+# The "q" model of investment
+
+## Based on Christopher D. Carroll's [Graduate Lecture Notes](http://www.econ2.jhu.edu/people/ccarroll/public/LectureNotes/Investment/qModel/) 
+
+Launch a live demonstration: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/econ-ark/DARKolo/HEAD?labpath=chimeras%2FqModel%2FqModel_in_HARK_and_Dolo.ipynb)


### PR DESCRIPTION
Adds a readme with a launch binder button to the qModel folder.

Also fixes dolang dependency.